### PR TITLE
Add CocoaLumberjack to list of logging backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ As the API has just launched, not many implementations exist yet. If you are int
 | [binaryscraping/swift-log-supabase](https://github.com/binaryscraping/swift-log-supabase) | a logging backend that sends log entries to [Supabase](https://github.com/supabase/supabase). |
 | [kiliankoe/swift-log-matrix](https://swiftpackageindex.com/kiliankoe/swift-log-matrix) | a logging backend for sending logs directly to a [Matrix](https://matrix.org) room |
 | [DiscordBM/DiscordLogger](https://github.com/DiscordBM/DiscordLogger) | a Discord logging implementation to send your logs over to a Discord channel in a good-looking manner and with a lot of configuration options including the ability to send only a few important log-levels such as `warning`/`error`/`critical`. |
+| [CocoaLumberjack](https://github.com/CocoaLumberjack/CocoaLumberjack) | a fast & simple, yet powerful & flexible logging framework for macOS, iOS, tvOS and watchOS, which includes a logging backend for swift-log. |
 | Your library? | [Get in touch!](https://forums.swift.org/c/server) |
 
 ## What is an API package?


### PR DESCRIPTION
Add's [CocoaLumberjack](https://github.com/CocoaLumberjack/CocoaLumberjack) to the list of logging backends.

### Motivation:

We've had a logging backend implementation for some time, but never added it here (simply forgot to do it).
https://github.com/CocoaLumberjack/CocoaLumberjack/issues/1356 now reminded us about it.

### Modifications:

- Extend the table in the README.

### Result:

- CocoaLumberjack is listed as a logging backend in the README.

Fixes https://github.com/CocoaLumberjack/CocoaLumberjack/issues/1356
